### PR TITLE
 Fallback to LicenseRef-OtherLicense on unknown license. 

### DIFF
--- a/builder/comp-builder.nix
+++ b/builder/comp-builder.nix
@@ -159,7 +159,11 @@ in stdenv.mkDerivation ({
   meta = {
     homepage = package.homepage;
     description = package.synopsis;
-    license = (import ../lib/cabal-licenses.nix lib).${package.license};
+    license =
+      let
+        license-map = import ../lib/cabal-licenses.nix lib;
+      in license-map.${package.license} or
+        (builtins.trace "WARNING: license \"${package.license}\" not found" license-map.LicenseRef-OtherLicense);
   };
 
   CABAL_CONFIG = configFiles + /cabal.config;

--- a/lib/cabal-licenses.nix
+++ b/lib/cabal-licenses.nix
@@ -9,7 +9,6 @@ lib: with lib.licenses;
   "GPL-2.0-only"  = gpl2;
   "GPL-3.0-only"  = gpl3;
   "Apache-2.0"    = asl20;
-  "(BSD-3-Clause OR Apache-2.0)" = bsd3OrAsl20;
   # Generic
   LicenseRef-Apache = "Apache";
   LicenseRef-GPL = "GPL";


### PR DESCRIPTION
revert previous commit: `bsd3OrAsl20` does not exist in `lib.licenses`.
