### PR TITLE
Add ghc-heap to the nonReinstallablePkgs

### DIFF
--- a/modules/component-driver.nix
+++ b/modules/component-driver.nix
@@ -16,7 +16,7 @@ in
 
   config.nonReinstallablePkgs =
     [ "rts" "ghc" "ghc-prim" "integer-gmp" "integer-simple" "base"
-    "array" "deepseq" "pretty" "ghc-boot-th" "template-haskell" ];
+    "array" "deepseq" "pretty" "ghc-boot-th" "template-haskell" "ghc-heap" ];
 
   options.hsPkgs = lib.mkOption {
     type = lib.types.unspecified;


### PR DESCRIPTION
This should better be aligned with the other set we have in
`default.nix`.  We are currently maintaining the list twice
in different locations.